### PR TITLE
make playerName in RankedLeaderboardEntry nullable

### DIFF
--- a/src/main/java/tech/zolhungaj/amqapi/servercommands/objects/RankedLeaderboardEntry.kt
+++ b/src/main/java/tech/zolhungaj/amqapi/servercommands/objects/RankedLeaderboardEntry.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.Json
 @JvmRecord
 data class RankedLeaderboardEntry(
     val score: Int,
-    @Json(name = "name") val playerName: String,
+    @Json(name = "name") val playerName: String?,
     val position: Int
 ) : Comparable<RankedLeaderboardEntry> {
     override fun compareTo(other: RankedLeaderboardEntry): Int {


### PR DESCRIPTION
Apparently this is the expected behaviour when an account is deleted after playing ranked. The null entry will persist on the server and in the events it emits until it is restarted