### PR TITLE
Fixes the game settings commands

### DIFF
--- a/src/main/java/tech/zolhungaj/amqapi/clientcommands/lobby/ChangeRoomSettings.java
+++ b/src/main/java/tech/zolhungaj/amqapi/clientcommands/lobby/ChangeRoomSettings.java
@@ -1,11 +1,14 @@
 package tech.zolhungaj.amqapi.clientcommands.lobby;
 
 import tech.zolhungaj.amqapi.clientcommands.CommandName;
-import tech.zolhungaj.amqapi.clientcommands.DirectDataCommand;
 import tech.zolhungaj.amqapi.sharedobjects.gamesettings.GameSettings;
 
-@DirectDataCommand("newSettings")
 @CommandName("change game settings")
 public record ChangeRoomSettings(
-        GameSettings newSettings
-) implements LobbyCommand {}
+        GameSettings newSettings,
+        Boolean communityMode
+) implements LobbyCommand {
+    public ChangeRoomSettings(GameSettings newSettings) {
+        this(newSettings, false);
+    }
+}

--- a/src/main/java/tech/zolhungaj/amqapi/clientcommands/roombrowser/HostMultiplayerRoom.java
+++ b/src/main/java/tech/zolhungaj/amqapi/clientcommands/roombrowser/HostMultiplayerRoom.java
@@ -1,17 +1,19 @@
 package tech.zolhungaj.amqapi.clientcommands.roombrowser;
 
 import tech.zolhungaj.amqapi.clientcommands.CommandName;
-import tech.zolhungaj.amqapi.clientcommands.DirectDataCommand;
 import tech.zolhungaj.amqapi.sharedobjects.gamesettings.GameSettings;
 
-@DirectDataCommand("settings")
 @CommandName("host room")
 public record HostMultiplayerRoom(
-        GameSettings settings
+        GameSettings settings,
+        Boolean communityMode
 ) implements RoomBrowserCommand {
     public HostMultiplayerRoom {
         var settingsBuilder = settings.toBuilder();
         settingsBuilder.gameMode(GameSettings.GameMode.MULTIPLAYER.value);
         settings = settingsBuilder.build();
+    }
+    public HostMultiplayerRoom(GameSettings settings) {
+        this(settings, false);
     }
 }

--- a/src/main/java/tech/zolhungaj/amqapi/clientcommands/roombrowser/HostSoloRoom.java
+++ b/src/main/java/tech/zolhungaj/amqapi/clientcommands/roombrowser/HostSoloRoom.java
@@ -1,17 +1,21 @@
 package tech.zolhungaj.amqapi.clientcommands.roombrowser;
 
 import tech.zolhungaj.amqapi.clientcommands.CommandName;
-import tech.zolhungaj.amqapi.clientcommands.DirectDataCommand;
 import tech.zolhungaj.amqapi.sharedobjects.gamesettings.GameSettings;
 
-@DirectDataCommand("settings")
 @CommandName("host solo room")
-public record HostSoloRoom(GameSettings settings) implements RoomBrowserCommand {
+public record HostSoloRoom(
+        GameSettings settings,
+        Boolean communityMode
+) implements RoomBrowserCommand {
     public HostSoloRoom {
         var settingsBuilder = settings.toBuilder();
         settingsBuilder
                 .gameMode(GameSettings.GameMode.SOLO.value)
                 .roomName("Solo");
         settings = settingsBuilder.build();
+    }
+    public HostSoloRoom(GameSettings settings) {
+        this(settings, false);
     }
 }


### PR DESCRIPTION
These have gone from being one object, to two objects encapsulated in one.

Technically this removes all the usages of DirectDataCommand, but I'll keep it around in case it's used for commands somewhere downstream.

TODO the GameSettings from the client and from the server must be separated due to a new entry "communityMode" that only exists in the one the server sends